### PR TITLE
Improve validation of content type in json-body

### DIFF
--- a/src/leiningen/new/mr_clojure/test_common.clj
+++ b/src/leiningen/new/mr_clojure/test_common.clj
@@ -11,5 +11,5 @@
 
    Fails pre-condition if content type is not application/json."
   [resp]
-  {:pre [(re-matches #"application/(.+)?json.+" (get-in resp [:headers "content-type"]))]}
+  {:pre [(re-matches #"application/(.+\+)?json.*" (get-in resp [:headers "content-type"]))]}
   (json/parse-string (:body resp) true))


### PR DESCRIPTION
Custom MIME types should end with +json.
Characters following json MIME type should be optional.

Currently, the prerequisite will fail with a content-type of "application/json" because it expects there to be at least one more character (presumably "; charset=utf-8")
