### PR TITLE
Updated versions for instrumented-ring-jetty-adapter and rest-client-driver

### DIFF
--- a/src/leiningen/new/mr_clojure/project.clj
+++ b/src/leiningen/new/mr_clojure/project.clj
@@ -8,7 +8,7 @@
                  [compojure "1.2.0"]
                  [environ "1.0.0"]
                  [mixradio/graphite-filter "1.0.0"]
-                 [mixradio/instrumented-ring-jetty-adapter "1.0.2"]
+                 [mixradio/instrumented-ring-jetty-adapter "1.0.4"]
                  [mixradio/radix "1.0.5"]
                  [net.logstash.logback/logstash-logback-encoder "3.2"]
                  [org.clojure/clojure "1.6.0"]
@@ -19,7 +19,7 @@
                log4j
                org.clojure/clojure]
 
-  :profiles {:dev {:dependencies [[com.github.rest-driver/rest-client-driver "1.1.36"
+  :profiles {:dev {:dependencies [[com.github.rest-driver/rest-client-driver "1.1.41"
                                    :exclusions [org.slf4j/slf4j-nop
                                                 javax.servlet/servlet-api
                                                 org.eclipse.jetty.orbit/javax.servlet]]


### PR DESCRIPTION
Need latest instrumented-ring-jetty-adapter to allow creation of SSL-enabled sites.
Need latest rest-driver to work with jetty 9.
