### PR TITLE
Replace typed env values with strings

### DIFF
--- a/src/leiningen/new/mr_clojure/project.clj
+++ b/src/leiningen/new/mr_clojure/project.clj
@@ -34,27 +34,27 @@
             [lein-release "1.0.5"]
             [lein-ring "0.8.12"]]
 
-  :env {:auto-reload true
+  :env {:auto-reload "true"
         :environment-name "poke"
-        :graphite-enabled false
+        :graphite-enabled "false"
         :graphite-host ""
-        :graphite-port 2003
-        :graphite-post-interval-seconds 60
+        :graphite-port "2003"
+        :graphite-post-interval-seconds "60"
         :logging-consolethreshold "info"
         :logging-filethreshold "info"
         :logging-level "info"
         :logging-path "/tmp"
         :logging-stashthreshold "off"
-        :production false
-        :requestlog-enabled false
-        :requestlog-retainhours 24
-        :restdriver-port 8081
+        :production "false"
+        :requestlog-enabled "false"
+        :requestlog-retainhours "24"
+        :restdriver-port "8081"
         :service-name "{{name}}"
-        :service-port 8080
+        :service-port "8080"
         :service-url "http://localhost:%s"
-        :shutdown-timeout-millis 5000
-        :start-timeout-seconds 120
-        :threads 254}
+        :shutdown-timeout-millis "5000"
+        :start-timeout-seconds "120"
+        :threads "254"}
 
   :lein-release {:deploy-via :shell
                  :shell ["lein" "do" "clean," "uberjar," "pom," "rpm"]}


### PR DESCRIPTION
Using typed values in the project.clj env map can produce subtle bugs that only appear after development when the app is deployed. The env map will only contain strings when deployed, since it will be populated via environment variables or system properties. Including typed values in the project.clj can cause apps to use env map values without parsing them correctly.

We should try to make it as clear as possible that the way environ works effectively dictates that env maps should _only_ contain strings.
