### PR TITLE
Updated curl command for route /hello example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ And now let's define our greet function:
 
 Save the file and give it a test:
 
-`curl localhost:8080/hello?nickname=world`
+`curl "http://localhost:8080/hello?nickname=world"`
 
 Should give us the output:
 


### PR DESCRIPTION
The curl didn't work unless escaped so used quotes to make the url easier to read and included the protocol.
