### PR TITLE
Add default service name to logback.xml

### DIFF
--- a/src/leiningen/new/mr_clojure/logback.xml
+++ b/src/leiningen/new/mr_clojure/logback.xml
@@ -12,9 +12,9 @@
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>${LOGGING_FILETHRESHOLD:-info}</level>
     </filter>
-    <file>${LOGGING_PATH:-/tmp}/${SERVICE_NAME}.log</file>
+    <file>${LOGGING_PATH:-/tmp}/${SERVICE_NAME:-{{name}}}.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOGGING_PATH:-/tmp}/${SERVICE_NAME}.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+      <fileNamePattern>${LOGGING_PATH:-/tmp}/${SERVICE_NAME:-{{name}}}.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
       <maxHistory>28</maxHistory>
     </rollingPolicy>
     <encoder>
@@ -36,9 +36,9 @@
       <level>${LOGGING_STASHTHRESHOLD:-warn}</level>
     </filter>
     <filter class="mixradio.metrics.GraphiteReporterFilter" />
-    <file>${LOGGING_PATH:-/tmp}/${SERVICE_NAME}-stash.log</file>
+    <file>${LOGGING_PATH:-/tmp}/${SERVICE_NAME:-{{name}}}-stash.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOGGING_PATH:-/tmp}/${SERVICE_NAME}-stash.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+      <fileNamePattern>${LOGGING_PATH:-/tmp}/${SERVICE_NAME:-{{name}}}-stash.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
       <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
         <maxFileSize>50MB</maxFileSize>
       </timeBasedFileNamingAndTriggeringPolicy>


### PR DESCRIPTION
Use the project name as the default service name in logback.xml. This still allows SERVICE_NAME to override the value, but avoids having files like `SERVICE_NAME_IS_UNDEFINED.log` created when running the app locally.
